### PR TITLE
feat: jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --ext .js,.ts,.jsx,.tsx --fix --quiet ./packages",
-    "build:dev": "rimraf dist && rollup --bundleConfigAsCjs --config scripts/rollup/dev.config.js",
     "demo": "vite serve demos/performance --config scripts/vite/vite.config.js --force",
-    "test": "jest --config scripts/jest/jest.config.js"
+    "build:dev": "rimraf dist && rollup --bundleConfigAsCjs --config scripts/rollup/react.config.js"
   },
   "keywords": [],
   "author": "",

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,0 +1,6 @@
+import { jsxDEV } from './src/jsx';
+
+export default {
+	version: '0.0.0-dev',
+	createElement: jsxDEV
+};

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "react",
+  "version": "1.0.0",
+  "description": "react common utils",
+  "module": "index.ts",
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/react/src/jsx.md
+++ b/packages/react/src/jsx.md
@@ -1,0 +1,10 @@
+```js
+import { jsx as _jsx } from 'react/jsx-runtime';
+
+/*#__PURE__*/ _jsx('div', {
+	children: '123'
+});
+
+// 或
+/*#__PURE__*/ React.createElement('div', null, '123');
+```

--- a/packages/react/src/jsx.ts
+++ b/packages/react/src/jsx.ts
@@ -1,0 +1,82 @@
+import { REACT_SYMBOL_TYPE } from 'shared/ReactSymbols';
+import { Type, Key, Ref, Props, ReactElementType, ElementType } from 'shared/ReactType';
+
+// ReactElement
+
+const ReactElement = (type: Type, key: Key, ref: Ref, props: Props): ReactElementType => {
+	const element = {
+		$$typeof: REACT_SYMBOL_TYPE,
+		type,
+		key,
+		ref,
+		props,
+		// 真实 react 是没有这个属性的，只是为了与真实的 React 实现进行区分
+		__mark: 'demo'
+	};
+	return element;
+};
+
+export const jsx = (type: ElementType, config: any, ...maybeChildren: any) => {
+	let key: Key = null;
+	let ref: Ref = null;
+	const props: Props = {};
+
+	for (const prop in config) {
+		const val = config[prop];
+		if (prop === 'key') {
+			if (val !== undefined && val !== null) {
+				// TODO: 这里为什么一定要是字符串
+				key = '' + val;
+			}
+			continue;
+		}
+		if (prop === 'ref') {
+			if (val !== undefined && val !== null) {
+				// TODO: 这里为什么一定要是字符串
+				ref = '' + val;
+			}
+			continue;
+		}
+		// 判断是否为自己的属性，而不是原型上的
+		if ({}.hasOwnProperty.call({}, prop)) {
+			props[prop] = val;
+		}
+
+		const maybeChildrenLength = maybeChildren.length;
+		if (maybeChildrenLength === 1) {
+			props.children = maybeChildren[0];
+		} else if (maybeChildrenLength > 1) {
+			props.children = maybeChildren;
+		}
+
+		return ReactElement(type, key, ref, props);
+	}
+};
+
+export const jsxDEV = (type: ElementType, config: any) => {
+	let key: Key = null;
+	const props: Props = {};
+	let ref: Ref = null;
+
+	for (const prop in config) {
+		const val = config[prop];
+		if (prop === 'key') {
+			if (val !== undefined) {
+				// TODO: 这里为什么一定要是字符串
+				key = '' + val;
+				continue;
+			}
+		}
+		if (prop === 'ref') {
+			if (val !== undefined) {
+				ref = val;
+				continue;
+			}
+		}
+		// 判断是否为自己的属性，而不是原型上的
+		if ({}.hasOwnProperty.call(config, prop)) {
+			props[prop] = val;
+		}
+		return ReactElement(type, key, ref, props);
+	}
+};

--- a/packages/shared/ReactSymbols.ts
+++ b/packages/shared/ReactSymbols.ts
@@ -1,0 +1,3 @@
+const supportedSymbols = typeof Symbol === 'function' && Symbol.for;
+
+export const REACT_SYMBOL_TYPE = supportedSymbols ? Symbol.for('react.element') : 0xec7;

--- a/packages/shared/ReactType.ts
+++ b/packages/shared/ReactType.ts
@@ -1,0 +1,14 @@
+export type Type = any;
+export type Key = any;
+export type Ref = any;
+export type Props = any;
+export type ElementType = any;
+
+export interface ReactElementType {
+	$$typeof: symbol | number;
+	type: ElementType | Type;
+	key: Key;
+	ref: Ref;
+	props: Props;
+	__mark: string;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "shared",
+  "version": "1.0.0",
+  "description": "所有公用的辅助方法及类型定义",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "shared": "workspace:*"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/scripts/rollup/react.config.js
+++ b/scripts/rollup/react.config.js
@@ -1,0 +1,53 @@
+import { getPackageJSON, resolvePkgPath, getBaseRollupPlugins } from './utils.js';
+import generatePackageJson from 'rollup-plugin-generate-package-json';
+
+const { name, module } = getPackageJSON('react');
+// 解析包路径
+const pkgPath = resolvePkgPath(name);
+// 解析产物路径
+const disPath = resolvePkgPath(name, true);
+
+export default [
+	// react
+	{
+		input: `${pkgPath}/${module}`,
+		output: {
+			file: `${disPath}/index.js`,
+			name: 'index.js',
+			format: 'umd'
+		},
+		external: ['react', 'react-dom'],
+		plugins: [getBaseRollupPlugins()]
+	},
+	// jsx-runtime
+	{
+		input: `${pkgPath}/src/jsx.ts`,
+		output: [
+			{
+				// jsx-runtime
+				file: `${disPath}/jsx-runtime.js`,
+				name: 'jsx-runtime.js',
+				format: 'umd'
+			},
+			{
+				// jsx-dev-runtime
+				file: `${disPath}/jsx-dev-runtime.js`,
+				name: 'jsx-dev-runtime.js',
+				format: 'umd'
+			}
+		],
+		plugins: [
+			...getBaseRollupPlugins(),
+			generatePackageJson({
+				inputFolder: pkgPath,
+				outputFolder: disPath,
+				baseContents: ({ version, name, description }) => ({
+					version,
+					name,
+					description,
+					main: 'index.js'
+				})
+			})
+		]
+	}
+];

--- a/scripts/rollup/utils.js
+++ b/scripts/rollup/utils.js
@@ -1,0 +1,32 @@
+import path from 'path';
+import fs from 'fs';
+
+import ts from 'rollup-plugin-typescript2';
+import cjs from '@rollup/plugin-commonjs';
+
+const pkgPath = path.resolve(__dirname, '../../packages');
+// react 规范中，如 react-demo 都在 node_modules 中
+const disPath = path.resolve(__dirname, '../../dist/node_modules');
+
+// 解析包路径
+export const resolvePkgPath = (pkgName, isDist) => {
+	if (isDist) {
+		return `${disPath}/${pkgName}`;
+	}
+	return `${pkgPath}/${pkgName}`;
+};
+
+export const getPackageJSON = (pkgName) => {
+	// ...包路径
+	const path = `${resolvePkgPath(pkgName)}/package.json`;
+	const pkg = fs.readFileSync(path, { encoding: 'utf8' });
+	// 序列化该 pkgName 的 package.json
+	return JSON.parse(pkg);
+};
+
+/**
+ * 获取所有基础 plugin：用于解析 commonJs 规范和 ts -> js(rollup-plugin-typescript2)
+ */
+export const getBaseRollupPlugins = ({ typescript = {} } = {}) => {
+	return [cjs(), ts(typescript)];
+};


### PR DESCRIPTION
## 实现 JSX
###  什么是 JSX
将 jsx 中的组件进行转换（不够准确）
```js
import { jsx as _jsx } from "react/jsx-runtime";

/*#__PURE__*/_jsx("div", {
  children: "123"
});

// 或
/*#__PURE__*/React.createElement("div", null, "123");
```

### 如何实现JSX
- jsxDEV方法（dev环境），对应文件：react/jsx-dev-runtime.js（dev环境）
- jsx方法（prod环境），对应文件：react/jsx-rumtime.js（prod环境）
- React.createElement方法，对应文件：React

#### 具体实现

